### PR TITLE
Remove $width property

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -38,16 +38,6 @@ class Html2Text
     protected $text;
 
     /**
-     * Maximum width of the formatted text, in columns.
-     *
-     * Set this value to 0 (or less) to ignore word wrapping
-     * and not constrain text to a fixed-width column.
-     *
-     * @type integer
-     */
-    protected $width = 70;
-
-    /**
      * List of preg* regular expression patterns to search for,
      * used in conjunction with $replace.
      *


### PR DESCRIPTION
$width property does not have any effect, since $options are used for this purpose. It is confusing, so property is removed.
